### PR TITLE
Change how fragment defconfig is passed to uboot

### DIFF
--- a/configs/platforms/am62xxsip-evm-rt.mk
+++ b/configs/platforms/am62xxsip-evm-rt.mk
@@ -17,8 +17,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62x_evm_a53_defconfig
-UBOOT_MACHINE_R5=am62x_evm_r5_defconfig
-UBOOT_MACHINE_R5_FRAGMENT=am62xsip_sk_r5.config
+UBOOT_MACHINE_R5=am62x_evm_r5_defconfig am62xsip_sk_r5.config
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi

--- a/configs/platforms/am62xxsip-evm.mk
+++ b/configs/platforms/am62xxsip-evm.mk
@@ -17,8 +17,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62x_evm_a53_defconfig
-UBOOT_MACHINE_R5=am62x_evm_r5_defconfig
-UBOOT_MACHINE_R5_FRAGMENT=am62xsip_sk_r5.config
+UBOOT_MACHINE_R5=am62x_evm_r5_defconfig am62xsip_sk_r5.config
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi

--- a/makerules/Makefile_u-boot
+++ b/makerules/Makefile_u-boot
@@ -24,7 +24,7 @@ u-boot-r5:
 	@echo    Building U-boot for R5
 	@echo ===================================
 	mkdir -p $(TI_SDK_PATH)/board-support/u-boot-build/r5
-	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm $(UBOOT_MACHINE_R5) $(if $(UBOOT_MACHINE_R5_FRAGMENT),$(UBOOT_MACHICE_R5_FRAGMENT),) O=$(TI_SDK_PATH)/board-support/u-boot-build/r5
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm $(UBOOT_MACHINE_R5) O=$(TI_SDK_PATH)/board-support/u-boot-build/r5
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE_ARMV7) \
 		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE)  O=$(TI_SDK_PATH)/board-support/u-boot-build/r5
 


### PR DESCRIPTION
Instead of creating a new variable, instead mention the fragment config with space and it will picked up by the makefile target.