### PR TITLE
Add fragment config for rt kernel

### DIFF
--- a/configs/platforms/am335x-evm-rt.mk
+++ b/configs/platforms/am335x-evm-rt.mk
@@ -10,6 +10,9 @@ ARCH=arm
 # u-boot machine config
 UBOOT_MACHINE=am335x_evm_defconfig
 
+# rt fragment
+RT_FRAGMENT=ti_rt.config
+
 # Override value of cross compiler
 export CROSS_COMPILE=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-
 export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)

--- a/configs/platforms/am437x-evm-rt.mk
+++ b/configs/platforms/am437x-evm-rt.mk
@@ -11,6 +11,9 @@ ARCH=arm
 # u-boot machine config
 UBOOT_MACHINE=am43xx_evm_defconfig
 
+# rt fragment
+RT_FRAGMENT=ti_rt.config
+
 # Override value of cross compiler
 export CROSS_COMPILE=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-
 export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)

--- a/configs/platforms/am62xx-evm-rt.mk
+++ b/configs/platforms/am62xx-evm-rt.mk
@@ -23,6 +23,9 @@ UBOOT_MACHINE=am62x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62x_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
 
+# rt fragment
+RT_FRAGMENT=ti_rt.config
+
 # Update platform, defconfig if PLATFORM=am62xx-lp-evm
 ifeq ($(PLATFORM),am62xx-lp-evm)
     UBOOT_MACHINE=am62x_lpsk_a53_defconfig

--- a/configs/platforms/am62xxsip-evm-rt.mk
+++ b/configs/platforms/am62xxsip-evm-rt.mk
@@ -20,6 +20,9 @@ UBOOT_MACHINE=am62x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62x_evm_r5_defconfig am62xsip_sk_r5.config
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
 
+# rt fragment
+RT_FRAGMENT=ti_rt.config
+
 KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)

--- a/configs/platforms/am64xx-evm-rt.mk
+++ b/configs/platforms/am64xx-evm-rt.mk
@@ -23,6 +23,9 @@ UBOOT_MACHINE=am64x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am64x_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am642-evm.dtb
 
+# rt fragment
+RT_FRAGMENT=ti_rt.config
+
 KERNEL_DEVICETREE_PREFIX=ti/k3-am64
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)

--- a/configs/platforms/am65xx-evm-rt.mk
+++ b/configs/platforms/am65xx-evm-rt.mk
@@ -20,6 +20,9 @@ UBOOT_MACHINE=am65x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am65x_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am654-base-board.dtb
 
+# rt fragment
+RT_FRAGMENT=ti_rt.config
+
 KERNEL_DEVICETREE_PREFIX=ti/k3-am654
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)

--- a/makerules/Makefile_linux
+++ b/makerules/Makefile_linux
@@ -4,7 +4,7 @@ linux: linux-dtbs u-boot
 	@echo     Building the Linux Kernel
 	@echo =================================
 	mkdir -p $(TI_SDK_PATH)/board-support/built-images
-	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config
+	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config $(RT_FRAGMENT)
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)  Image Image.gz
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) modules
 	# Build FitImage

--- a/makerules/Makefile_linux-dtbs
+++ b/makerules/Makefile_linux-dtbs
@@ -6,7 +6,7 @@ linux-dtbs:
 	@echo =====================================
 	@echo     Building the Linux Kernel DTBs
 	@echo =====================================
-	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config
+	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config $(RT_FRAGMENT)
 	@for DTB in $(KERNEL_DEVICETREE); do \
 		$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) DTC_FLAGS=-@ ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) $$DTB; \
 	done

--- a/makerules/Makefile_linux-extras
+++ b/makerules/Makefile_linux-extras
@@ -4,7 +4,7 @@ linux-extras: linux-extras-dtbs u-boot-extras
 	@echo     Building the Linux Kernel
 	@echo =================================
 	mkdir -p $(TI_SDK_PATH)/board-support/built-images
-	$(MAKE) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config
+	$(MAKE) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config $(RT_FRAGMENT)
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)  Image Image.gz
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) modules
 	# Build FitImage

--- a/makerules/Makefile_linux-extras-dtbs
+++ b/makerules/Makefile_linux-extras-dtbs
@@ -3,7 +3,7 @@ linux-extras-dtbs:
 	@echo =====================================
 	@echo     Building the Linux Kernel DTBs
 	@echo =====================================
-	$(MAKE) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config
+	$(MAKE) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config $(RT_FRAGMENT)
 	@for DTB in $(KERNEL_DEVICETREE); do \
 		$(MAKE) -j $(MAKE_JOBS) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) DTC_FLAGS=-@ ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) $$DTB; \
 	done

--- a/makerules/Makefile_linux-legacy
+++ b/makerules/Makefile_linux-legacy
@@ -4,7 +4,7 @@ linux: linux-dtbs
 	@echo     Building the Linux Kernel
 	@echo =================================
 	mkdir -p $(TI_SDK_PATH)/board-support/built-images
-	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) multi_v7_defconfig ti_multi_v7_prune.config no_smp.config
+	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) multi_v7_defconfig ti_multi_v7_prune.config no_smp.config $(RT_FRAGMENT)
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) zImage
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) modules
 

--- a/makerules/Makefile_linux-legacy-dtbs
+++ b/makerules/Makefile_linux-legacy-dtbs
@@ -7,7 +7,7 @@ linux-dtbs:
 	@echo =====================================
 	@echo     Building the Linux Kernel DTBs
 	@echo =====================================
-	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) multi_v7_defconfig ti_multi_v7_prune.config no_smp.config
+	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) multi_v7_defconfig ti_multi_v7_prune.config no_smp.config $(RT_FRAGMENT)
 	@for DTB in $(KERNEL_DEVICETREE); do \
 		$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) DTC_FLAGS=-@ ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) $$DTB; \
 	done


### PR DESCRIPTION
make defconfig needs to include a fragment config when building a rt image. So add a new variable RT_FRAGMENT for rt makefile and also for all platforms.