### PR TITLE
Add target product variable for am65

### DIFF
--- a/configs/platforms/am65xx-evm-rt.mk
+++ b/configs/platforms/am65xx-evm-rt.mk
@@ -1,6 +1,9 @@
 #platform
 SOC=am65
 
+# for ti-sgx
+TARGET_PRODUCT=ti654x
+
 #add platform for scripts
 PLATFORM?=am65xx-evm
 

--- a/configs/platforms/am65xx-evm.mk
+++ b/configs/platforms/am65xx-evm.mk
@@ -1,6 +1,9 @@
 #platform
 SOC=am65
 
+# for ti-sgx
+TARGET_PRODUCT=ti654x
+
 #add platform for scripts
 PLATFORM?=am65xx-evm
 


### PR DESCRIPTION
Add TARGET_PRODUCT=ti654x in config file for am65 for rt and non rt. This is needed for ti-sgx makefile.