### PR TITLE
Remove pdm anamoly detection target from am65

### DIFF
--- a/configs/platforms/am65xx-evm-rt.mk
+++ b/configs/platforms/am65xx-evm-rt.mk
@@ -32,4 +32,4 @@ TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
-MAKE_ALL_TARGETS?= arm-benchmarks oprofile-example pru-icss cryptodev u-boot linux linux-dtbs pdm-anomaly-detection matrix-gui ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= arm-benchmarks oprofile-example pru-icss cryptodev u-boot linux linux-dtbs matrix-gui ti-sgx-ddk-km

--- a/configs/platforms/am65xx-evm.mk
+++ b/configs/platforms/am65xx-evm.mk
@@ -29,4 +29,4 @@ TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
-MAKE_ALL_TARGETS?= arm-benchmarks oprofile-example pru-icss cryptodev u-boot linux linux-dtbs pdm-anomaly-detection matrix-gui ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= arm-benchmarks oprofile-example pru-icss cryptodev u-boot linux linux-dtbs matrix-gui ti-sgx-ddk-km


### PR DESCRIPTION
makefile target for pdm anamoly detection has a package bug due to compiler hence removing it now for linux and rt linux.