### PR TITLE
am62pxx-evm: Fix fitimage build for am62p

### DIFF
--- a/configs/platforms/am62pxx-evm-rt.mk
+++ b/configs/platforms/am62pxx-evm-rt.mk
@@ -26,7 +26,7 @@ UBOOT_MACHINE=am62px_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62px_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62p5-sk.dtb
 
-KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5
+KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -23,7 +23,7 @@ UBOOT_MACHINE=am62px_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62px_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62p5-sk.dtb
 
-KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5
+KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin


### PR DESCRIPTION
fitimage build needs some dtb overlays which are missing when
 device trees are parsed. Add the missing dtbs