### PR TITLE
configs: platforms: Update UBOOT_MACHINE for am62xxsip

### DIFF
--- a/configs/platforms/am62xxsip-evm-rt.mk
+++ b/configs/platforms/am62xxsip-evm-rt.mk
@@ -16,8 +16,8 @@ export CROSS_COMPILE_ARMV7=$(K3_R5_LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linu
 export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 # u-boot machine configs for A53 and R5
-UBOOT_MACHINE=am62x_evm_a53_defconfig
-UBOOT_MACHINE_R5=am62x_evm_r5_defconfig am62xsip_sk_r5.config
+UBOOT_MACHINE=am62xsip_evm_a53_defconfig
+UBOOT_MACHINE_R5=am62xsip_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
 
 # rt fragment

--- a/configs/platforms/am62xxsip-evm.mk
+++ b/configs/platforms/am62xxsip-evm.mk
@@ -16,8 +16,8 @@ export CROSS_COMPILE_ARMV7=$(K3_R5_LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linu
 export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 # u-boot machine configs for A53 and R5
-UBOOT_MACHINE=am62x_evm_a53_defconfig
-UBOOT_MACHINE_R5=am62x_evm_r5_defconfig am62xsip_sk_r5.config
+UBOOT_MACHINE=am62xsip_evm_a53_defconfig
+UBOOT_MACHINE_R5=am62xsip_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi


### PR DESCRIPTION
Update a53 and r5 defconfig names for am62xxsip based on U-Boot 2024.04 [1]

[1] https://git.ti.com/cgit/ti-u-boot/ti-u-boot/commit/?h=ti-u-boot-2024.04&id=df5181f8c6c41bf018ec043d565581b5d8a291c5