### PR TITLE
Revert "configs: Temporarily remove jailhouse targets"

### DIFF
--- a/configs/platforms/am62pxx-evm-rt.mk
+++ b/configs/platforms/am62pxx-evm-rt.mk
@@ -39,4 +39,4 @@ PVR_BUILD_DIR=am62p_linux
 RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=wayland
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -36,4 +36,4 @@ PVR_BUILD_DIR=am62p_linux
 RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=wayland
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras

--- a/configs/platforms/am62xx-evm-rt.mk
+++ b/configs/platforms/am62xx-evm-rt.mk
@@ -46,4 +46,4 @@ PVR_BUILD_DIR=am62_linux
 RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=wayland
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras

--- a/configs/platforms/am62xx-evm.mk
+++ b/configs/platforms/am62xx-evm.mk
@@ -43,4 +43,4 @@ PVR_BUILD_DIR=am62_linux
 RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=wayland
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras


### PR DESCRIPTION
- Add jailhouse support back in Top Level Makefile of SDK Installer.

- This reverts commit a62f020c74799ad566e5933c3fbd23dc974229f4.