### PR TITLE
ti-tisdk-makefile: Add support for AM62L

### DIFF
--- a/configs/platforms/am62lxx-evm-rt.mk
+++ b/configs/platforms/am62lxx-evm-rt.mk
@@ -1,0 +1,32 @@
+#platform
+SOC=am62l
+
+#add platform for scripts
+PLATFORM?=am62lxx-evm
+
+#Architecture
+ARCH=arm64
+
+#ARM Toolchains
+export CROSS_COMPILE=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/usr/bin/aarch64-oe-linux/aarch64-oe-linux-
+
+#Default CC value to be used when cross compiling.  This is so that the
+#GNU Make default of "cc" is not used to point to the host compiler
+export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
+
+# rt fragment
+RT_FRAGMENT=ti_rt.config
+
+# u-boot machine config
+UBOOT_MACHINE=am62lx_evm_defconfig
+
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62l3-evm.dtb
+
+KERNEL_DEVICETREE_PREFIX=ti/k3-am62l
+
+TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
+UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl1.bin
+UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
+UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
+
+MAKE_ALL_TARGETS?= arm-benchmarks u-boot linux linux-dtbs

--- a/configs/platforms/am62lxx-evm.mk
+++ b/configs/platforms/am62lxx-evm.mk
@@ -1,0 +1,29 @@
+#platform
+SOC=am62l
+
+#add platform for scripts
+PLATFORM?=am62lxx-evm
+
+#Architecture
+ARCH=arm64
+
+#ARM Toolchains
+export CROSS_COMPILE=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/usr/bin/aarch64-oe-linux/aarch64-oe-linux-
+
+#Default CC value to be used when cross compiling.  This is so that the
+#GNU Make default of "cc" is not used to point to the host compiler
+export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
+
+# u-boot machine config
+UBOOT_MACHINE=am62lx_evm_defconfig
+
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62l3-evm.dtb
+
+KERNEL_DEVICETREE_PREFIX=ti/k3-am62l
+
+TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
+UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl1.bin
+UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
+UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
+
+MAKE_ALL_TARGETS?= arm-benchmarks u-boot linux linux-dtbs

--- a/makerules/Makefile_linux
+++ b/makerules/Makefile_linux
@@ -11,9 +11,16 @@ linux: linux-dtbs u-boot
 	cd $(LINUXKERNEL_INSTALL_DIR) ; cp arch/arm64/boot/Image.gz ./linux.bin ; cd ..
 	cp $(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/fitImage-its-$(PLATFORM) $(LINUXKERNEL_INSTALL_DIR)
 	mkimage -r -f $(LINUXKERNEL_INSTALL_DIR)/fitImage-its-$(PLATFORM) -k $(UBOOT_SRC_DIR)/board/ti/keys -K $(TI_SDK_PATH)/board-support/u-boot-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
-	# Rebuild uboot a53 for FitImage
+	# Rebuild uboot a53 (binman) for FitImage
+ifeq ($(SOC), am62l)
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
-    BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) O=$(TI_SDK_PATH)/board-support/u-boot-build/a53
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL1=$(UBOOT_AP_TRUSTED_ROM) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) \
+		O=$(TI_SDK_PATH)/board-support/u-boot-build/a53
+else
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) \
+		O=$(TI_SDK_PATH)/board-support/u-boot-build/a53
+endif
 
 linux_stage: linux-dtbs_stage u-boot_stage
 	cp $(LINUXKERNEL_INSTALL_DIR)/arch/arm64/boot/Image $(TI_SDK_PATH)/board-support/built-images

--- a/makerules/Makefile_u-boot
+++ b/makerules/Makefile_u-boot
@@ -1,7 +1,6 @@
+u-boot: $(if $(filter am62l,$(SOC)), u-boot-a53, u-boot-r5 u-boot-a53)
 
-u-boot: u-boot-r5 u-boot-a53
-
-u-boot_clean: u-boot-a53_clean u-boot-r5_clean
+u-boot_clean: $(if $(filter am62l,$(SOC)), u-boot-a53_clean, u-boot-r5_clean u-boot-a53_clean)
 
 u-boot-a53:
 	@echo ===================================
@@ -9,8 +8,16 @@ u-boot-a53:
 	@echo ===================================
 	mkdir -p $(TI_SDK_PATH)/board-support/u-boot-build/a53
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm $(UBOOT_MACHINE) O=$(TI_SDK_PATH)/board-support/u-boot-build/a53
+
+ifeq ($(SOC), am62l)
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
-		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) O=$(TI_SDK_PATH)/board-support/u-boot-build/a53
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL1=$(UBOOT_AP_TRUSTED_ROM) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) \
+		O=$(TI_SDK_PATH)/board-support/u-boot-build/a53
+else
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) \
+		O=$(TI_SDK_PATH)/board-support/u-boot-build/a53
+endif
 
 u-boot-a53_clean:
 	@echo ===================================
@@ -20,6 +27,12 @@ u-boot-a53_clean:
 		distclean
 
 u-boot-r5:
+
+ifeq ($(SOC), am62l)
+	$(warning Target u-boot-r5 isn't applicable for AM62L)
+	$(error Skipping with a warning message)
+endif
+
 	@echo ===================================
 	@echo    Building U-boot for R5
 	@echo ===================================
@@ -29,6 +42,12 @@ u-boot-r5:
 		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE)  O=$(TI_SDK_PATH)/board-support/u-boot-build/r5
 
 u-boot-r5_clean:
+
+ifeq ($(SOC), am62l)
+	$(warning Target u-boot-r5_clean isn't applicable for AM62L)
+	$(error Skipping with a warning message)
+endif
+
 	@echo ===================================
 	@echo    Cleaning U-boot for R5
 	@echo ===================================
@@ -40,7 +59,13 @@ u-boot_stage:
 	mkdir -p $(TI_SDK_PATH)/board-support/built-images
 	cp $(TI_SDK_PATH)/board-support/u-boot-build/a53/tispl.bin $(TI_SDK_PATH)/board-support/built-images/tispl.bin
 	cp $(TI_SDK_PATH)/board-support/u-boot-build/a53/u-boot.img $(TI_SDK_PATH)/board-support/built-images/u-boot.img
+
+ifeq ($(SOC), am62l)
+	cp $(TI_SDK_PATH)/board-support/u-boot-build/a53/tiboot3*.bin $(TI_SDK_PATH)/board-support/built-images/
+else
 	cp $(TI_SDK_PATH)/board-support/u-boot-build/r5/tiboot3*.bin $(TI_SDK_PATH)/board-support/built-images/
+endif
+
 ifeq ($(SOC), $(filter $(SOC), j721e am65x))
 	cp $(TI_SDK_PATH)/board-support/u-boot-build/r5/sysfw*.itb $(TI_SDK_PATH)/board-support/built-images/
 endif


### PR DESCRIPTION
- Add platform support for AM62L Linux & RT-Linux

- Update u-boot Makefile to support AM62L. This involves passing BL1 to binman, skipping u-boot-r5 build & copying boot binaries from relevant locations.