### PR TITLE
configs:platforms: Update makefile configs for ti-img-rogue-driver

### DIFF
--- a/configs/platforms/am62pxx-evm-rt.mk
+++ b/configs/platforms/am62pxx-evm-rt.mk
@@ -33,7 +33,6 @@ UBOOTEXTRAS_SRC_DIR=$(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62p_linux
-RGX_BVNC="36.53.104.796"
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -30,7 +30,6 @@ UBOOTEXTRAS_SRC_DIR=$(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62p_linux
-RGX_BVNC="36.53.104.796"
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 

--- a/configs/platforms/am62xx-evm-rt.mk
+++ b/configs/platforms/am62xx-evm-rt.mk
@@ -40,7 +40,6 @@ UBOOTEXTRAS_SRC_DIR=$(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62_linux
-RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 

--- a/configs/platforms/am62xx-evm.mk
+++ b/configs/platforms/am62xx-evm.mk
@@ -37,7 +37,6 @@ UBOOTEXTRAS_SRC_DIR=$(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62_linux
-RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 

--- a/configs/platforms/am62xxsip-evm-rt.mk
+++ b/configs/platforms/am62xxsip-evm-rt.mk
@@ -31,7 +31,6 @@ UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62_linux
-RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 

--- a/configs/platforms/am62xxsip-evm.mk
+++ b/configs/platforms/am62xxsip-evm.mk
@@ -28,7 +28,6 @@ UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62_linux
-RGX_BVNC="33.15.11.3"
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 

--- a/makerules/Makefile_ti-img-rogue-driver
+++ b/makerules/Makefile_ti-img-rogue-driver
@@ -4,13 +4,13 @@ ti-img-rogue-driver: linux
 	@echo =====================================
 	@echo     Building ti-img-rogue-driver
 	@echo =====================================
-	$(MAKE) -C $(IMG_ROGUE_SRC_DIR) ARCH=$(ARCH) KERNELDIR=${LINUXKERNEL_INSTALL_DIR} RGX_BVNC=${RGX_BVNC} BUILD=${PVR_BUILD} PVR_BUILD_DIR=${PVR_BUILD_DIR} WINDOW_SYSTEM=${WINDOW_SYSTEM}
+	$(MAKE) -C $(IMG_ROGUE_SRC_DIR) ARCH=$(ARCH) KERNELDIR=${LINUXKERNEL_INSTALL_DIR} BUILD=${PVR_BUILD} PVR_BUILD_DIR=${PVR_BUILD_DIR} WINDOW_SYSTEM=${WINDOW_SYSTEM}
 
 ti-img-rogue-driver_clean:
 	@echo ====================================
 	@echo     Cleaning ti-img-rogue-driver
 	@echo ====================================
-	$(MAKE) -C $(IMG_ROGUE_SRC_DIR) ARCH=$(ARCH) KERNELDIR=${LINUXKERNEL_INSTALL_DIR} RGX_BVNC=${RGX_BVNC} BUILD=${PVR_BUILD} PVR_BUILD_DIR=${PVR_BUILD_DIR} WINDOW_SYSTEM=${WINDOW_SYSTEM} clean
+	$(MAKE) -C $(IMG_ROGUE_SRC_DIR) ARCH=$(ARCH) KERNELDIR=${LINUXKERNEL_INSTALL_DIR} BUILD=${PVR_BUILD} PVR_BUILD_DIR=${PVR_BUILD_DIR} WINDOW_SYSTEM=${WINDOW_SYSTEM} clean
 
 ti-img-rogue-driver_install:
 	@echo ====================================


### PR DESCRIPTION
- Remove `RGX_BVNC` definition from all platform configurations.
- Skip passing `RGX_BVNC` to the makefile, as it is already defined within the makefile itself.