### PR TITLE
makerules: Update key-directory passed to mkimage

### DIFF
--- a/makerules/Makefile_linux
+++ b/makerules/Makefile_linux
@@ -10,7 +10,7 @@ linux: linux-dtbs u-boot
 	# Build FitImage
 	cd $(LINUXKERNEL_INSTALL_DIR) ; cp arch/arm64/boot/Image.gz ./linux.bin ; cd ..
 	cp $(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/fitImage-its-$(PLATFORM) $(LINUXKERNEL_INSTALL_DIR)
-	mkimage -r -f $(LINUXKERNEL_INSTALL_DIR)/fitImage-its-$(PLATFORM) -k $(UBOOT_SRC_DIR)/board/ti/keys -K $(TI_SDK_PATH)/board-support/u-boot-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
+	mkimage -r -f $(LINUXKERNEL_INSTALL_DIR)/fitImage-its-$(PLATFORM) -k $(UBOOT_SRC_DIR)/arch/arm/mach-k3/keys -K $(TI_SDK_PATH)/board-support/u-boot-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
 	# Rebuild uboot a53 (binman) for FitImage
 ifeq ($(SOC), am62l)
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \

--- a/makerules/Makefile_linux-extras
+++ b/makerules/Makefile_linux-extras
@@ -10,7 +10,7 @@ linux-extras: linux-extras-dtbs u-boot-extras
 	# Build FitImage
 	cd $(LINUXEXTRASKERNEL_INSTALL_DIR) ; cp arch/arm64/boot/Image.gz ./linux.bin ; cd ..
 	cp $(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)-jailhouse/fitImage-its-$(PLATFORM) $(LINUXEXTRASKERNEL_INSTALL_DIR)
-	mkimage -r -f $(LINUXEXTRASKERNEL_INSTALL_DIR)/fitImage-its-$(PLATFORM) -k $(UBOOTEXTRAS_SRC_DIR)/board/ti/keys -K $(TI_SDK_PATH)/board-support/u-boot-extras-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
+	mkimage -r -f $(LINUXEXTRASKERNEL_INSTALL_DIR)/fitImage-its-$(PLATFORM) -k $(UBOOTEXTRAS_SRC_DIR)/arch/arm/mach-k3/keys -K $(TI_SDK_PATH)/board-support/u-boot-extras-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
 	# Rebuild uboot a53 for FitImage
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOTEXTRAS_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
     BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) O=$(TI_SDK_PATH)/board-support/u-boot-extras-build/a53


### PR DESCRIPTION
- U-Boot tree doesn't have any `board/ti/keys` directory containing keys to use for signing was incorrect.

- The keys are located in `arch/arm/mach-k3/keys` under U-Boot sources [1]. Hence, update the mkimage command to pass this directory.

[1]: https://git.ti.com/cgit/ti-u-boot/ti-u-boot/tree/arch/arm/mach-k3/keys?h=ti-u-boot-2024.04