### PR TITLE
configs: platforms: Drop ti-sgx-ddk-km from MAKE_ALL_TARGETS

### DIFF
--- a/configs/platforms/am335x-evm-rt.mk
+++ b/configs/platforms/am335x-evm-rt.mk
@@ -19,4 +19,4 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 KERNEL_DEVICETREE_PREFIX=am335x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi

--- a/configs/platforms/am335x-evm.mk
+++ b/configs/platforms/am335x-evm.mk
@@ -16,4 +16,4 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 KERNEL_DEVICETREE_PREFIX=am335x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi

--- a/configs/platforms/am335x-hs-evm-rt.mk
+++ b/configs/platforms/am335x-hs-evm-rt.mk
@@ -25,4 +25,4 @@ export GCC_ARM_NONE_TOOLCHAIN=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/u
 
 KERNEL_DEVICETREE_PREFIX=am335x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi

--- a/configs/platforms/am335x-hs-evm.mk
+++ b/configs/platforms/am335x-hs-evm.mk
@@ -22,4 +22,4 @@ export GCC_ARM_NONE_TOOLCHAIN=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/u
 
 KERNEL_DEVICETREE_PREFIX=am335x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen mmwavegesture-hmi evse-hmi protection-relays-hmi

--- a/configs/platforms/am437x-evm-rt.mk
+++ b/configs/platforms/am437x-evm-rt.mk
@@ -20,4 +20,4 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 KERNEL_DEVICETREE_PREFIX=am437x-|am43x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi

--- a/configs/platforms/am437x-evm.mk
+++ b/configs/platforms/am437x-evm.mk
@@ -17,4 +17,4 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 KERNEL_DEVICETREE_PREFIX=am437x-|am43x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi

--- a/configs/platforms/am437x-hs-evm-rt.mk
+++ b/configs/platforms/am437x-hs-evm-rt.mk
@@ -26,4 +26,4 @@ export GCC_ARM_NONE_TOOLCHAIN=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/u
 
 KERNEL_DEVICETREE_PREFIX=am437x-|am43x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi

--- a/configs/platforms/am437x-hs-evm.mk
+++ b/configs/platforms/am437x-hs-evm.mk
@@ -23,4 +23,4 @@ export GCC_ARM_NONE_TOOLCHAIN=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux/u
 
 KERNEL_DEVICETREE_PREFIX=am437x-|am43x-
 
-MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= pru-icss matrix-gui cryptodev secdev u-boot-legacy linux-legacy linux-legacy-dtbs refresh-screen image-gallery mmwavegesture-hmi evse-hmi

--- a/configs/platforms/am65xx-evm-rt.mk
+++ b/configs/platforms/am65xx-evm-rt.mk
@@ -32,4 +32,4 @@ TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs

--- a/configs/platforms/am65xx-evm.mk
+++ b/configs/platforms/am65xx-evm.mk
@@ -29,4 +29,4 @@ TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-sgx-ddk-km
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs


### PR DESCRIPTION
We don't package sources for ti-sgx-ddk-km under tisdk-core-bundle [1] Hence, drop it from MAKE_ALL_TARGETS to avoid installer build failures

[1]: https://git.ti.com/cgit/ti-sdk-linux/meta-tisdk/tree/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb?h=kirkstone#n25