### PR TITLE
Add Makefile support for trusted-firmware-a

### DIFF
--- a/configs/platforms/am62lxx-evm-rt.mk
+++ b/configs/platforms/am62lxx-evm-rt.mk
@@ -24,9 +24,11 @@ MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62l3-evm.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am62l
 
+TFA_SPD?=opteed
+
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
-UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl1.bin
-UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
+UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/built-images/bl1.bin
+UBOOT_ATF=$(TI_SDK_PATH)/board-support/built-images/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
-MAKE_ALL_TARGETS?= arm-benchmarks u-boot linux linux-dtbs
+MAKE_ALL_TARGETS?= arm-benchmarks atf u-boot linux linux-dtbs

--- a/configs/platforms/am62lxx-evm.mk
+++ b/configs/platforms/am62lxx-evm.mk
@@ -21,9 +21,11 @@ MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62l3-evm.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am62l
 
+TFA_SPD?=opteed
+
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
-UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl1.bin
-UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
+UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/built-images/bl1.bin
+UBOOT_ATF=$(TI_SDK_PATH)/board-support/built-images/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 
-MAKE_ALL_TARGETS?= arm-benchmarks u-boot linux linux-dtbs
+MAKE_ALL_TARGETS?= arm-benchmarks atf u-boot linux linux-dtbs

--- a/configs/setup/tisdk-installer.mk
+++ b/configs/setup/tisdk-installer.mk
@@ -15,5 +15,6 @@ IMG_ROGUE_SRC_DIR=$(TI_SDK_PATH)/board-support/extra-drivers/ti-img-rogue-driver
 UBOOT_SRC_DIR=$(TI_SDK_PATH)/board-support/ti-u-boot*
 KIG_SRC_DIR=$(TI_SDK_PATH)/board-support/k3-image-gen-*
 LINUXKERNEL_INSTALL_DIR=$(TI_SDK_PATH)/board-support/ti-linux-kernel*
+TFA_SRC_DIR=$(TI_SDK_PATH)/board-support/trusted-firmware-a*
 
 export TI_SECURE_DEV_PKG=$(TI_SDK_PATH)/board-support/core-secdev-k3

--- a/makerules/Makefile_trusted-firmware-a
+++ b/makerules/Makefile_trusted-firmware-a
@@ -1,0 +1,23 @@
+atf: atf_build atf_stage
+
+atf_build:
+	@echo =======================
+	@echo    Building TFA
+	@echo =======================
+	mkdir -p $(TI_SDK_PATH)/board-support/tfa-build
+	$(MAKE) -j $(MAKE_JOBS) -C $(TFA_SRC_DIR) ARCH=aarch64 CROSS_COMPILE=$(CROSS_COMPILE) O=$(TI_SDK_PATH)/board-support/tfa-build \
+                PLAT=k3 K3_PM_SYSTEM_SUSPEND=1 TARGET_BOARD=$(SOC) SPD=$(TFA_SPD)
+
+atf_clean:
+	@echo =======================
+	@echo    Cleaning TFA
+	@echo =======================
+	$(MAKE) -j $(MAKE_JOBS) -C $(TFA_SRC_DIR) CROSS_COMPILE=$(CROSS_COMPILE) O=$(TI_SDK_PATH)/board-support/tfa-build distclean
+
+atf_stage:
+        mkdir -p $(TI_SDK_PATH)/board-support/built-images
+        cp $(TI_SDK_PATH)/board-support/tfa-build/bl31.bin $(TI_SDK_PATH)/board-support/built-images/bl31.bin
+
+ifeq ($(SOC), am62l)
+        cp $(TI_SDK_PATH)/board-support/tfa-build/bl1.bin $(TI_SDK_PATH)/board-support/built-images/bl1.bin
+endif

--- a/makerules/Makefile_u-boot
+++ b/makerules/Makefile_u-boot
@@ -1,4 +1,4 @@
-u-boot: $(if $(filter am62l,$(SOC)), u-boot-a53, u-boot-r5 u-boot-a53)
+u-boot: $(if $(filter am62l,$(SOC)), atf u-boot-a53, u-boot-r5 u-boot-a53)
 
 u-boot_clean: $(if $(filter am62l,$(SOC)), u-boot-a53_clean, u-boot-r5_clean u-boot-a53_clean)
 


### PR DESCRIPTION
- Add Makefile_trusted-firmware-a with targets atf, atf_build, atf_clean & atf_stage

- Add atf in MAKE_ALL_TARGETS for am62lxx-evm & am62lxx-evm-rt

- For am62l, point UBOOT_AP_TRUSTED_ROM & UBOOT_ATF to board-support/built-images/

- In Makefile_u-boot, add a dependency of building atf before u-boot-a53 for am62l.