### PR TITLE
configs: platforms: am62pxx: Pick overlays for V3Link cameras

### DIFF
--- a/configs/platforms/am62pxx-evm-rt.mk
+++ b/configs/platforms/am62pxx-evm-rt.mk
@@ -23,7 +23,7 @@ UBOOT_MACHINE=am62px_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62px_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62p5-sk.dtb
 
-KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk
+KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk|ti/k3-v3link
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -20,7 +20,7 @@ UBOOT_MACHINE=am62px_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62px_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62p5-sk.dtb
 
-KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk
+KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk|ti/k3-v3link
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin


### PR DESCRIPTION
Overlays for interfacing OV5640 sensor with V3Link are built as part of the TI linux kernel [1]. So, add an entry for it in SDK Makefile

[1]: https://git.ti.com/cgit/arago-project/meta-ti/commit/?h=scarthgap&id=a4defea6f5bd69b6e5a5fde3b88f5f0e80d11f6b