### PR TITLE
configs:platforms: Update the dtb file path in u-boot machine configs

### DIFF
--- a/configs/platforms/am62pxx-evm-rt.mk
+++ b/configs/platforms/am62pxx-evm-rt.mk
@@ -21,7 +21,7 @@ RT_FRAGMENT=ti_rt.config
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62px_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62px_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62p5-sk.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62p5-sk.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk|ti/k3-v3link
 

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -18,7 +18,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62px_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62px_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62p5-sk.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62p5-sk.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am62p5|ti/k3-am62x-sk|ti/k3-v3link
 

--- a/configs/platforms/am62xx-evm-rt.mk
+++ b/configs/platforms/am62xx-evm-rt.mk
@@ -18,7 +18,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62x_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am625-sk.dtb
 
 # rt fragment
 RT_FRAGMENT=ti_rt.config
@@ -27,7 +27,7 @@ RT_FRAGMENT=ti_rt.config
 ifeq ($(PLATFORM),am62xx-lp-evm)
     UBOOT_MACHINE=am62x_lpsk_a53_defconfig
     UBOOT_MACHINE_R5=am62x_lpsk_r5_defconfig
-    MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62-lp-sk.dtb
+    MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62-lp-sk.dtb
 endif
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi

--- a/configs/platforms/am62xx-evm.mk
+++ b/configs/platforms/am62xx-evm.mk
@@ -18,13 +18,13 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62x_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am625-sk.dtb
 
 # Update platform, defconfig if PLATFORM=am62xx-lp-evm
 ifeq ($(PLATFORM),am62xx-lp-evm)
     UBOOT_MACHINE=am62x_lpsk_a53_defconfig
     UBOOT_MACHINE_R5=am62x_lpsk_r5_defconfig
-    MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am62-lp-sk.dtb
+    MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62-lp-sk.dtb
 endif
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi

--- a/configs/platforms/am62xxsip-evm-rt.mk
+++ b/configs/platforms/am62xxsip-evm-rt.mk
@@ -18,7 +18,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62xsip_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62xsip_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am625-sk.dtb
 
 # rt fragment
 RT_FRAGMENT=ti_rt.config

--- a/configs/platforms/am62xxsip-evm.mk
+++ b/configs/platforms/am62xxsip-evm.mk
@@ -18,7 +18,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am62xsip_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62xsip_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am625-sk.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am625-sk.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi
 

--- a/configs/platforms/am64xx-evm-rt.mk
+++ b/configs/platforms/am64xx-evm-rt.mk
@@ -18,7 +18,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for a53 and r5
 UBOOT_MACHINE=am64x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am64x_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am642-evm.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am642-evm.dtb
 
 # rt fragment
 RT_FRAGMENT=ti_rt.config

--- a/configs/platforms/am64xx-evm.mk
+++ b/configs/platforms/am64xx-evm.mk
@@ -18,7 +18,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for a53 and r5
 UBOOT_MACHINE=am64x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am64x_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am642-evm.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am642-evm.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am64
 

--- a/configs/platforms/am65xx-evm-rt.mk
+++ b/configs/platforms/am65xx-evm-rt.mk
@@ -21,7 +21,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am65x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am65x_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am654-base-board.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am654-base-board.dtb
 
 # rt fragment
 RT_FRAGMENT=ti_rt.config

--- a/configs/platforms/am65xx-evm.mk
+++ b/configs/platforms/am65xx-evm.mk
@@ -21,7 +21,7 @@ export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 # u-boot machine configs for A53 and R5
 UBOOT_MACHINE=am65x_evm_a53_defconfig
 UBOOT_MACHINE_R5=am65x_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/arch/arm/dts/k3-am654-base-board.dtb
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am654-base-board.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am654
 


### PR DESCRIPTION
Update ``MKIMAGE_DTB_FILE`` path related to u-boot 2025.01 migration.
dtb files path changed from ``a53/arch/arm/dts/`` to ``a53/dts/upstream/src/arm64/ti/``