### PR TITLE
makerules: update linux-extras, u-boot-extras makefiles to build AM62L

### DIFF
--- a/makerules/Makefile_linux-extras
+++ b/makerules/Makefile_linux-extras
@@ -7,13 +7,20 @@ linux-extras: linux-extras-dtbs u-boot-extras
 	$(MAKE) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config $(RT_FRAGMENT)
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)  Image Image.gz
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXEXTRASKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) modules
+	
 	# Build FitImage
 	cd $(LINUXEXTRASKERNEL_INSTALL_DIR) ; cp arch/arm64/boot/Image.gz ./linux.bin ; cd ..
 	cp $(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)-jailhouse/fitImage-its-$(PLATFORM) $(LINUXEXTRASKERNEL_INSTALL_DIR)
 	mkimage -r -f $(LINUXEXTRASKERNEL_INSTALL_DIR)/fitImage-its-$(PLATFORM) -k $(UBOOTEXTRAS_SRC_DIR)/arch/arm/mach-k3/keys -K $(TI_SDK_PATH)/board-support/u-boot-extras-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
+	
 	# Rebuild uboot a53 for FitImage
+ifeq ($(SOC), am62l)
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOTEXTRAS_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
+    BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL1=$(UBOOT_AP_TRUSTED_ROM) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) O=$(TI_SDK_PATH)/board-support/u-boot-extras-build/a53
+else
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOTEXTRAS_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
     BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) O=$(TI_SDK_PATH)/board-support/u-boot-extras-build/a53
+endif
 
 linux-extras_stage: linux-extras-dtbs_stage u-boot-extras_stage
 	cp $(LINUXEXTRASKERNEL_INSTALL_DIR)/arch/arm64/boot/Image $(TI_SDK_PATH)/board-support/built-images

--- a/makerules/Makefile_u-boot-extras
+++ b/makerules/Makefile_u-boot-extras
@@ -1,7 +1,7 @@
 
-u-boot-extras: u-boot-extras-r5 u-boot-extras-a53
+u-boot-extras: $(if $(filter am62l,$(SOC)), atf u-boot-extras-a53, u-boot-extras-r5 u-boot-extras-a53)
 
-u-boot-extras_clean: u-boot-extras-a53_clean u-boot-extras-r5_clean
+u-boot-extras_clean: $(if $(filter am62l,$(SOC)), u-boot-extras-a53_clean, u-boot-extras-r5_clean u-boot-extras-a53_clean)
 
 u-boot-extras-a53:
 	@echo ===================================
@@ -9,8 +9,14 @@ u-boot-extras-a53:
 	@echo ===================================
 	mkdir -p $(TI_SDK_PATH)/board-support/u-boot-extras-build/a53
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOTEXTRAS_SRC_DIR) ARCH=arm $(UBOOT_MACHINE) O=$(TI_SDK_PATH)/board-support/u-boot-extras-build/a53
+
+ifeq ($(SOC), am62l)
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOTEXTRAS_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL1=$(UBOOT_AP_TRUSTED_ROM) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) O=$(TI_SDK_PATH)/board-support/u-boot-extras-build/a53
+else
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOTEXTRAS_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
 		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) O=$(TI_SDK_PATH)/board-support/u-boot-extras-build/a53
+endif
 
 u-boot-extras-a53_clean:
 	@echo ===================================
@@ -52,7 +58,13 @@ u-boot-extras_stage:
 	mkdir -p $(TI_SDK_PATH)/board-support/built-images
 	cp $(TI_SDK_PATH)/board-support/u-boot-extras-build/a53/tispl.bin $(TI_SDK_PATH)/board-support/built-images/tispl.bin
 	cp $(TI_SDK_PATH)/board-support/u-boot-extras-build/a53/u-boot.img $(TI_SDK_PATH)/board-support/built-images/u-boot.img
+
+ifeq ($(SOC), am62l)
+	cp $(TI_SDK_PATH)/board-support/u-boot-extras-build/a53/tiboot3*.bin $(TI_SDK_PATH)/board-support/built-images/
+else
 	cp $(TI_SDK_PATH)/board-support/u-boot-extras-build/r5/tiboot3*.bin $(TI_SDK_PATH)/board-support/built-images/
+endif
+
 ifeq ($(SOC), $(filter $(SOC), j721e am65x))
 	cp $(TI_SDK_PATH)/board-support/u-boot-build/r5/sysfw*.itb $(TI_SDK_PATH)/board-support/built-images/
 endif


### PR DESCRIPTION
Update the makefiles to add AM62L specific makerules. This commit in continuation to the 49b702e1a488427d89a6cb432c8e57fa7b6ac758 commit enables building and enabling the binaries through makefiles.