### PR TITLE
AM62L: platforms: Disable optee during TFA build

### DIFF
--- a/configs/platforms/am62lxx-evm-rt.mk
+++ b/configs/platforms/am62lxx-evm-rt.mk
@@ -24,7 +24,7 @@ MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62l3-evm.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am62l
 
-TFA_SPD?=opteed
+TFA_SPD?=none
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/built-images/bl1.bin

--- a/configs/platforms/am62lxx-evm.mk
+++ b/configs/platforms/am62lxx-evm.mk
@@ -21,7 +21,7 @@ MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62l3-evm.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am62l
 
-TFA_SPD?=opteed
+TFA_SPD?=none
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/built-images/bl1.bin


### PR DESCRIPTION
Set TFA_SPD to none diabling optee since optee is not included.

