### PR TITLE
makerules: Makefile_linux: Update the variable name for am62a

### DIFF
--- a/configs/platforms/am335x-evm.mk
+++ b/configs/platforms/am335x-evm.mk
@@ -4,6 +4,7 @@ TARGET_PRODUCT=ti335x
 
 #add platform for scripts
 PLATFORM?=am335x-evm
+YOCTO_MACHINE?=am335x-evm
 
 ARCH=arm
 

--- a/configs/platforms/am335x-hs-evm.mk
+++ b/configs/platforms/am335x-hs-evm.mk
@@ -4,6 +4,7 @@ TARGET_PRODUCT=ti335x
 
 #add platform for scripts
 PLATFORM?=am335x-hs-evm
+YOCTO_MACHINE?=am335x-hs-evm
 
 ARCH=arm
 

--- a/configs/platforms/am437x-evm.mk
+++ b/configs/platforms/am437x-evm.mk
@@ -4,6 +4,7 @@ TARGET_PRODUCT=ti437x
 
 #add platform for scripts
 PLATFORM?=am437x-evm
+YOCTO_MACHINE?=am437x-evm
 
 #Architecture
 ARCH=arm

--- a/configs/platforms/am437x-hs-evm.mk
+++ b/configs/platforms/am437x-hs-evm.mk
@@ -4,6 +4,7 @@ TARGET_PRODUCT=ti437x
 
 #add platform for scripts
 PLATFORM?=am437x-hs-evm
+YOCTO_MACHINE?=am437x-hs-evm
 
 #Architecture
 ARCH=arm

--- a/configs/platforms/am62axx-evm.mk
+++ b/configs/platforms/am62axx-evm.mk
@@ -3,7 +3,7 @@ SOC=am62a
 
 #add platform for scripts
 PLATFORM?=am62a-evm
-
+YOCTO_MACHINE?=am62axx-evm
 ARCH=arm64
 
 #Set cross compilers

--- a/configs/platforms/am62lxx-evm.mk
+++ b/configs/platforms/am62lxx-evm.mk
@@ -3,6 +3,7 @@ SOC=am62l
 
 #add platform for scripts
 PLATFORM?=am62lxx-evm
+YOCTO_MACHINE?=am62lxx-evm
 
 #Architecture
 ARCH=arm64

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -3,6 +3,7 @@ SOC=am62p
 
 #add platform for scripts
 PLATFORM?=am62pxx-evm
+YOCTO_MACHINE?=am62pxx-evm
 
 #Architecture
 ARCH=arm64

--- a/configs/platforms/am62xx-evm.mk
+++ b/configs/platforms/am62xx-evm.mk
@@ -3,6 +3,7 @@ SOC=am62
 
 #add platform for scripts
 PLATFORM?=am62xx-evm
+YOCTO_MACHINE?=am62xx-evm
 
 #Architecture
 ARCH=arm64

--- a/configs/platforms/am62xxsip-evm.mk
+++ b/configs/platforms/am62xxsip-evm.mk
@@ -3,6 +3,7 @@ SOC=am62sip
 
 #add platform for scripts
 PLATFORM?=am62xxsip-evm
+YOCTO_MACHINE?=am62xxsip-evm
 
 #Architecture
 ARCH=arm64

--- a/configs/platforms/am64xx-evm.mk
+++ b/configs/platforms/am64xx-evm.mk
@@ -3,6 +3,7 @@ SOC=am64
 
 #add platform for scripts
 PLATFORM?=am64xx-evm
+YOCTO_MACHINE?=am64xx-evm
 
 #Architecture
 ARCH=arm64

--- a/configs/platforms/am65xx-evm.mk
+++ b/configs/platforms/am65xx-evm.mk
@@ -6,6 +6,7 @@ TARGET_PRODUCT=ti654x
 
 #add platform for scripts
 PLATFORM?=am65xx-evm
+YOCTO_MACHINE?=am65xx-evm
 
 #Architecture
 ARCH=arm64

--- a/makerules/Makefile_linux
+++ b/makerules/Makefile_linux
@@ -7,10 +7,12 @@ linux: linux-dtbs u-boot
 	$(MAKE) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) defconfig ti_arm64_prune.config $(RT_FRAGMENT)
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)  Image Image.gz
 	$(MAKE) -j $(MAKE_JOBS) -C $(LINUXKERNEL_INSTALL_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) modules
+	
 	# Build FitImage
 	cd $(LINUXKERNEL_INSTALL_DIR) ; cp arch/arm64/boot/Image.gz ./linux.bin ; cd ..
-	cp $(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/fitImage-its-$(PLATFORM) $(LINUXKERNEL_INSTALL_DIR)
-	mkimage -r -f $(LINUXKERNEL_INSTALL_DIR)/fitImage-its-$(PLATFORM) -k $(UBOOT_SRC_DIR)/arch/arm/mach-k3/keys -K $(TI_SDK_PATH)/board-support/u-boot-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
+	cp $(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/fitImage-its-$(YOCTO_MACHINE) $(LINUXKERNEL_INSTALL_DIR)
+	mkimage -r -f $(LINUXKERNEL_INSTALL_DIR)/fitImage-its-$(YOCTO_MACHINE) -k $(UBOOT_SRC_DIR)/arch/arm/mach-k3/keys -K $(TI_SDK_PATH)/board-support/u-boot-build/$(MKIMAGE_DTB_FILE) $(TI_SDK_PATH)/board-support/built-images/fitImage
+
 	# Rebuild uboot a53 (binman) for FitImage
 ifeq ($(SOC), am62l)
 	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \


### PR DESCRIPTION
- Since the Platform name is different for am62a compared to other devices, introduce a new variable for am62axx-evm in configs/platforms/am62axx-evm.mk and refer to that variable when required.