### PR TITLE
configs:platforms: Pass TI_DM as empty string for am64x

### DIFF
--- a/configs/platforms/am64xx-evm.mk
+++ b/configs/platforms/am64xx-evm.mk
@@ -26,6 +26,6 @@ KERNEL_DEVICETREE_PREFIX=ti/k3-am64
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
-
+TI_DM = ""
 
 MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs


### PR DESCRIPTION
In continuation with the commit 2a2b29efe8818d44896fadeae7eca2b7fb8e8bec, in am64xx-evm.mk pass TI_DM as empty string since DM firmware is not applicable for am64x [0].

[0]: https://git.ti.com/cgit/arago-project/meta-ti/tree/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti.inc?h=scarthgap#n69