### PR TITLE
configs: platforms: Update KERNEL_DEVICETREE_PREFIX for am62dxx

### DIFF
--- a/configs/platforms/am62dxx-evm.mk
+++ b/configs/platforms/am62dxx-evm.mk
@@ -19,7 +19,7 @@ UBOOT_MACHINE=am62dx_evm_a53_defconfig
 UBOOT_MACHINE_R5=am62dx_evm_r5_defconfig
 MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62d2-evm.dtb
 
-KERNEL_DEVICETREE_PREFIX=ti/k3-am62d2
+KERNEL_DEVICETREE_PREFIX=ti/k3-am62d2|ti/k3-am62a7-sk-edgeai
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin


### PR DESCRIPTION
Update KERNEL_DEVICETREE_PREFIX to package k3-am62a7-sk-edgeai.dtbo overlay as in [1] required for audio analytics for am62dxx-evm.

[1]: https://github.com/TexasInstruments/meta-tisdk/commit/d02e8a69a51ab12422eb0021a96d3635c3adf61f