### PR TITLE
configs: platforms: Update uboot defconfigs and device tree prefixes

### DIFF
--- a/configs/platforms/am62xxsip-evm.mk
+++ b/configs/platforms/am62xxsip-evm.mk
@@ -17,11 +17,11 @@ export CROSS_COMPILE_ARMV7=$(K3_R5_LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linu
 export CC=$(CROSS_COMPILE)gcc --sysroot=$(SDK_PATH_TARGET)
 
 # u-boot machine configs for A53 and R5
-UBOOT_MACHINE=am62xsip_evm_a53_defconfig
-UBOOT_MACHINE_R5=am62xsip_evm_r5_defconfig
-MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am625-sk.dtb
+UBOOT_MACHINE=am6254xxl_evm_a53_defconfig
+UBOOT_MACHINE_R5=am6254xxl_evm_r5_defconfig
+MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am6254xxl-sk.dtb
 
-KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62-|ti/k3-am62x|ti/k3-am62.dtsi
+KERNEL_DEVICETREE_PREFIX=ti/k3-am625|ti/k3-am62x-sk
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin


### PR DESCRIPTION
For am62xxsip-evm, defconfigs are updated[1] to new u-boot machine variables. Hence update that in the top level makefile here.

While at it, Update the KERNEL_DEVICETREE_PREFIX expression to align with [1], ensuring that built DTBs are consistent and compatible with those produced by Yocto.

[1]: https://git.ti.com/cgit/arago-project/meta-ti/tree/meta-ti-bsp/conf/machine/am62xxsip-evm.conf?h=11.01.04