### PR TITLE
AM62L: platforms: Enable optee during TFA build

### DIFF
--- a/configs/platforms/am62lxx-evm.mk
+++ b/configs/platforms/am62lxx-evm.mk
@@ -22,7 +22,7 @@ MKIMAGE_DTB_FILE=a53/dts/upstream/src/arm64/ti/k3-am62l3-evm.dtb
 
 KERNEL_DEVICETREE_PREFIX=ti/k3-am62l
 
-TFA_SPD?=none
+TFA_SPD?=opteed
 
 TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/built-images/bl1.bin


### PR DESCRIPTION
Set TFA_SPD to opteed as newer silicon revision(1.1) of AM62L family boots with OP-TEE enabled[1].

[1]: https://git.ti.com/cgit/arago-project/meta-ti/commit/?h=11.01.11&id=0a02cd559a07af33a8111a1f5777b14862a52227