### PR TITLE
makerules: resolve glob patterns in KERNELDIR paths for ti-img-rogue-driver

### DIFF
--- a/configs/platforms/am62lxx-evm.mk
+++ b/configs/platforms/am62lxx-evm.mk
@@ -28,7 +28,7 @@ TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_AP_TRUSTED_ROM=$(TI_SDK_PATH)/board-support/built-images/bl1.bin
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/built-images/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
-LINUXEXTRASKERNEL_INSTALL_DIR=$(TI_SDK_PATH)/board-support/linux-extras-*
-UBOOTEXTRAS_SRC_DIR=$(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*
+LINUXEXTRASKERNEL_INSTALL_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/linux-extras-*)
+UBOOTEXTRAS_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*)
 
 MAKE_ALL_TARGETS?= arm-benchmarks atf cryptodev u-boot linux linux-dtbs jailhouse linux-extras linux-extras-dtbs u-boot-extras

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -27,8 +27,8 @@ TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 TI_DM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/ti-dm/am62pxx/ipc_echo_testb_mcu1_0_release_strip.xer5f
-LINUXEXTRASKERNEL_INSTALL_DIR=$(TI_SDK_PATH)/board-support/linux-extras-*
-UBOOTEXTRAS_SRC_DIR=$(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*
+LINUXEXTRASKERNEL_INSTALL_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/linux-extras-*)
+UBOOTEXTRAS_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*)
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62p_linux

--- a/configs/platforms/am62xx-evm.mk
+++ b/configs/platforms/am62xx-evm.mk
@@ -35,8 +35,8 @@ TI_LINUX_FIRMWARE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)
 UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 TI_DM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/ti-dm/am62xx/ipc_echo_testb_mcu1_0_release_strip.xer5f
-LINUXEXTRASKERNEL_INSTALL_DIR=$(TI_SDK_PATH)/board-support/linux-extras-*
-UBOOTEXTRAS_SRC_DIR=$(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*
+LINUXEXTRASKERNEL_INSTALL_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/linux-extras-*)
+UBOOTEXTRAS_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*)
 
 # Add configs for ti-img-rogue-driver
 PVR_BUILD_DIR=am62_linux

--- a/configs/setup/tisdk-installer.mk
+++ b/configs/setup/tisdk-installer.mk
@@ -7,14 +7,14 @@ SDK_PATH_TARGET=$(LINUX_DEVKIT_PATH)/sysroots/aarch64-oe-linux
 SDK_PATH_HOST=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux
 
 # The source directories for each component
-ARM_BENCHMARKS_SRC_DIR=$(TI_SDK_PATH)/example-applications/*arm-benchmarks*
-AM_SYSINFO_SRC_DIR=$(TI_SDK_PATH)/example-applications/*am-sysinfo*
-OPROFILE_SRC_DIR=$(TI_SDK_PATH)/example-applications/*oprofile-example*
-CRYPTODEV_SRC_DIR=$(TI_SDK_PATH)/board-support/extra-drivers/cryptodev*
-IMG_ROGUE_SRC_DIR=$(TI_SDK_PATH)/board-support/extra-drivers/ti-img-rogue-driver*
-UBOOT_SRC_DIR=$(TI_SDK_PATH)/board-support/ti-u-boot*
-KIG_SRC_DIR=$(TI_SDK_PATH)/board-support/k3-image-gen-*
-LINUXKERNEL_INSTALL_DIR=$(TI_SDK_PATH)/board-support/ti-linux-kernel*
-TFA_SRC_DIR=$(TI_SDK_PATH)/board-support/trusted-firmware-a*
+ARM_BENCHMARKS_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/example-applications/*arm-benchmarks*)
+AM_SYSINFO_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/example-applications/*am-sysinfo*)
+OPROFILE_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/example-applications/*oprofile-example*)
+CRYPTODEV_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/extra-drivers/cryptodev*)
+IMG_ROGUE_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/extra-drivers/ti-img-rogue-driver*)
+UBOOT_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/ti-u-boot*)
+KIG_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/k3-image-gen-*)
+LINUXKERNEL_INSTALL_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/ti-linux-kernel*)
+TFA_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/trusted-firmware-a*)
 
 export TI_SECURE_DEV_PKG=$(TI_SDK_PATH)/board-support/core-secdev-k3

--- a/configs/setup/tisdk-installer.mk
+++ b/configs/setup/tisdk-installer.mk
@@ -8,12 +8,9 @@ SDK_PATH_HOST=$(LINUX_DEVKIT_PATH)/sysroots/x86_64-arago-linux
 
 # The source directories for each component
 ARM_BENCHMARKS_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/example-applications/*arm-benchmarks*)
-AM_SYSINFO_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/example-applications/*am-sysinfo*)
-OPROFILE_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/example-applications/*oprofile-example*)
 CRYPTODEV_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/extra-drivers/cryptodev*)
 IMG_ROGUE_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/extra-drivers/ti-img-rogue-driver*)
 UBOOT_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/ti-u-boot*)
-KIG_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/k3-image-gen-*)
 LINUXKERNEL_INSTALL_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/ti-linux-kernel*)
 TFA_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/trusted-firmware-a*)
 


### PR DESCRIPTION
The ti-img-rogue-driver build fail when LINUXKERNEL_INSTALL_DIR contains glob patterns (e.g., "linux-*"). These patterns are not expanded when passed as make variables to nested builds, causing KERNELDIR to point to non-existent paths.

Fix by using $(shell ls -d ...) to expand the glob pattern before passing KERNELDIR to the sub-make invocations. This ensures the full resolved path is used in both build and clean targets.

The fix has been extended to ti-sgx-ddk-km build preemptively.