### PR TITLE
atf: Update the SOC variable to check for am62lx

### DIFF
--- a/makerules/Makefile_atf
+++ b/makerules/Makefile_atf
@@ -18,6 +18,6 @@ atf_stage:
 	mkdir -p $(TI_SDK_PATH)/board-support/built-images
 	cp $(TI_SDK_PATH)/board-support/tfa-build/k3low/$(SOC)/release/bl31.bin $(TI_SDK_PATH)/board-support/built-images/bl31.bin
 
-ifeq ($(SOC), am62l)
+ifeq ($(SOC), am62lx)
 	cp $(TI_SDK_PATH)/board-support/tfa-build/k3low/$(SOC)/release/bl1.bin $(TI_SDK_PATH)/board-support/built-images/bl1.bin
 endif


### PR DESCRIPTION
With the change at commit [0], for AM62L, ATF copies bl1.bin from board-support/tfa-build/k3low/am62lx/release/ folder in the installer. Update the if condition to check for the "am62lx" string.

[0]: https://github.com/TexasInstruments/ti-tisdk-makefile/commit/b3ae6a89f93566759314daad59168367f364ef91