### PR TITLE
add snagboot makefile

### DIFF
--- a/configs/platforms/am62axx-evm.mk
+++ b/configs/platforms/am62axx-evm.mk
@@ -26,4 +26,4 @@ UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 TI_DM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/ti-dm/am62axx/dm_edgeai_mcu1_0_release_strip.out
 
-MAKE_ALL_TARGETS?= cryptodev u-boot linux linux-dtbs
+MAKE_ALL_TARGETS?= cryptodev u-boot u-boot-snagboot linux linux-dtbs

--- a/configs/platforms/am62dxx-evm.mk
+++ b/configs/platforms/am62dxx-evm.mk
@@ -26,4 +26,4 @@ UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 TI_DM=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/ti-dm/am62dxx/ipc_echo_testb_mcu1_0_release_strip.xer5f
 
-MAKE_ALL_TARGETS?= cryptodev arm-benchmarks u-boot linux linux-dtbs
+MAKE_ALL_TARGETS?= cryptodev arm-benchmarks u-boot u-boot-snagboot linux linux-dtbs

--- a/configs/platforms/am62lxx-evm.mk
+++ b/configs/platforms/am62lxx-evm.mk
@@ -31,4 +31,4 @@ UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 LINUXEXTRASKERNEL_INSTALL_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/linux-extras-*)
 UBOOTEXTRAS_SRC_DIR:=$(shell ls -d $(TI_SDK_PATH)/board-support/u-boot-extras-jailhouse-*)
 
-MAKE_ALL_TARGETS?= arm-benchmarks atf cryptodev u-boot linux linux-dtbs jailhouse linux-extras linux-extras-dtbs u-boot-extras
+MAKE_ALL_TARGETS?= arm-benchmarks atf cryptodev u-boot u-boot-snagboot linux linux-dtbs jailhouse linux-extras linux-extras-dtbs u-boot-extras

--- a/configs/platforms/am62pxx-evm.mk
+++ b/configs/platforms/am62pxx-evm.mk
@@ -35,4 +35,4 @@ PVR_BUILD_DIR=am62p_linux
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot u-boot-snagboot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras

--- a/configs/platforms/am62xx-evm.mk
+++ b/configs/platforms/am62xx-evm.mk
@@ -43,4 +43,4 @@ PVR_BUILD_DIR=am62_linux
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot u-boot-snagboot linux linux-dtbs ti-img-rogue-driver jailhouse linux-extras linux-extras-dtbs u-boot-extras

--- a/configs/platforms/am62xxsip-evm.mk
+++ b/configs/platforms/am62xxsip-evm.mk
@@ -33,4 +33,4 @@ PVR_BUILD_DIR=am62_linux
 WINDOW_SYSTEM=lws-generic
 PVR_BUILD=release
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs ti-img-rogue-driver
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot u-boot-snagboot linux linux-dtbs ti-img-rogue-driver

--- a/configs/platforms/am64xx-evm.mk
+++ b/configs/platforms/am64xx-evm.mk
@@ -28,4 +28,4 @@ UBOOT_ATF=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl31.bin
 UBOOT_TEE=$(TI_SDK_PATH)/board-support/prebuilt-images/$(PLATFORM)/bl32.bin
 TI_DM = ""
 
-MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot linux linux-dtbs
+MAKE_ALL_TARGETS?= arm-benchmarks cryptodev u-boot u-boot-snagboot linux linux-dtbs

--- a/makerules/Makefile_u-boot-snagboot
+++ b/makerules/Makefile_u-boot-snagboot
@@ -1,0 +1,85 @@
+# Snagboot-specific U-Boot build
+# Builds bootloader images with DFU boot and fastboot support required by
+# snagrecover and snagfactory. Images are staged to built-images/snagboot/.
+#
+# Supported platforms: am62xx-evm, am62xx-lp-evm, am62axx-evm, am62dxx-evm,
+#                      am62pxx-evm, am62xxsip-evm, am64xx-evm, am62lxx-evm
+#
+# Usage:
+#   make u-boot-snagboot_clean
+#   make u-boot-snagboot
+#   make u-boot-snagboot_stage
+
+UBOOT_SNAGBOOT_BUILD_A53=$(TI_SDK_PATH)/board-support/u-boot-build/snagboot/a53
+UBOOT_SNAGBOOT_BUILD_R5=$(TI_SDK_PATH)/board-support/u-boot-build/snagboot/r5
+UBOOT_SNAGBOOT_IMAGES=$(TI_SDK_PATH)/board-support/built-images/snagboot
+
+# am64 only needs the snagfactory fragment; all other SOCs also get the usbdfu fragments
+ifeq ($(SOC), am64)
+UBOOT_MACHINE_SNAGBOOT=$(UBOOT_MACHINE) am6x_a53_snagfactory.config
+UBOOT_MACHINE_R5_SNAGBOOT=$(UBOOT_MACHINE_R5)
+else
+UBOOT_MACHINE_SNAGBOOT=$(UBOOT_MACHINE) am62x_a53_usbdfu.config am6x_a53_snagfactory.config
+ifneq ($(UBOOT_MACHINE_R5),)
+UBOOT_MACHINE_R5_SNAGBOOT=$(UBOOT_MACHINE_R5) am62x_r5_usbdfu.config
+endif
+endif
+
+u-boot-snagboot: $(if $(filter am62lx,$(SOC)), u-boot-snagboot-a53, u-boot-snagboot-r5 u-boot-snagboot-a53)
+
+u-boot-snagboot_clean: $(if $(filter am62lx,$(SOC)), u-boot-snagboot-a53_clean, u-boot-snagboot-r5_clean u-boot-snagboot-a53_clean)
+
+u-boot-snagboot-a53:
+	@echo ===================================
+	@echo    Building U-boot snagboot for A53
+	@echo ===================================
+	mkdir -p $(UBOOT_SNAGBOOT_BUILD_A53)
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm $(UBOOT_MACHINE_SNAGBOOT) O=$(UBOOT_SNAGBOOT_BUILD_A53)
+ifeq ($(SOC), am62lx)
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL1=$(UBOOT_AP_TRUSTED_ROM) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) \
+		O=$(UBOOT_SNAGBOOT_BUILD_A53)
+else
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" \
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) BL31=$(UBOOT_ATF) TEE=$(UBOOT_TEE) TI_DM=$(TI_DM) \
+		O=$(UBOOT_SNAGBOOT_BUILD_A53)
+endif
+
+u-boot-snagboot-a53_clean:
+	@echo ===================================
+	@echo    Cleaning U-boot snagboot for A53
+	@echo ===================================
+	$(MAKE) -C $(UBOOT_SRC_DIR) CROSS_COMPILE=$(CROSS_COMPILE) O=$(UBOOT_SNAGBOOT_BUILD_A53) distclean
+
+u-boot-snagboot-r5:
+ifeq ($(SOC), am62lx)
+	$(warning Target u-boot-snagboot-r5 isn't applicable for AM62L)
+	$(error Skipping with a warning message)
+endif
+	@echo ===================================
+	@echo    Building U-boot snagboot for R5
+	@echo ===================================
+	mkdir -p $(UBOOT_SNAGBOOT_BUILD_R5)
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm $(UBOOT_MACHINE_R5_SNAGBOOT) O=$(UBOOT_SNAGBOOT_BUILD_R5)
+	$(MAKE) -j $(MAKE_JOBS) -C $(UBOOT_SRC_DIR) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE_ARMV7) \
+		BINMAN_INDIRS=$(TI_LINUX_FIRMWARE) O=$(UBOOT_SNAGBOOT_BUILD_R5) KBUILD_LDFLAGS="-no-pie"
+
+u-boot-snagboot-r5_clean:
+ifeq ($(SOC), am62lx)
+	$(warning Target u-boot-snagboot-r5_clean isn't applicable for AM62L)
+	$(error Skipping with a warning message)
+endif
+	@echo ===================================
+	@echo    Cleaning U-boot snagboot for R5
+	@echo ===================================
+	$(MAKE) -C $(UBOOT_SRC_DIR) CROSS_COMPILE=$(CROSS_COMPILE_ARMV7) O=$(UBOOT_SNAGBOOT_BUILD_R5) distclean
+
+u-boot-snagboot_stage:
+	mkdir -p $(UBOOT_SNAGBOOT_IMAGES)
+	cp $(UBOOT_SNAGBOOT_BUILD_A53)/tispl.bin $(UBOOT_SNAGBOOT_IMAGES)/tispl.bin
+	cp $(UBOOT_SNAGBOOT_BUILD_A53)/u-boot.img $(UBOOT_SNAGBOOT_IMAGES)/u-boot.img
+ifeq ($(SOC), am62lx)
+	cp $(UBOOT_SNAGBOOT_BUILD_A53)/tiboot3*.bin $(UBOOT_SNAGBOOT_IMAGES)/
+else
+	cp $(UBOOT_SNAGBOOT_BUILD_R5)/tiboot3*.bin $(UBOOT_SNAGBOOT_IMAGES)/
+endif


### PR DESCRIPTION
add snagboot makefile to build u-boot
binaries for snagrecover and snagflash.
include make u-boot-snagboot to makefiles of
these platforms-:
      - am62xx-evm
      - am62axx-evm
      - am62dxx-evm
      - am62pxx-evm
      - am62xxsip-evm
      - am64xx-evm
      - am62lxx-evm